### PR TITLE
Fix OrderFieldMigration in Doctrine 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	"require":{
 		"php":">=7.4",
 		"contao/core-bundle":"^4.13 || ^5.0",
+		"doctrine/dbal":"^3.3 || ^4.0",
 		"madeyourday/contao-rocksolid-columns":"^2.0",
 		"madeyourday/contao-rocksolid-slider":"^2.0"
 	},

--- a/src/Migration/OrderFieldMigration.php
+++ b/src/Migration/OrderFieldMigration.php
@@ -44,7 +44,7 @@ class OrderFieldMigration extends AbstractMigration
                 continue;
             }
 
-            $columns = $schemaManager->listTableColumns($table);
+            $columns = $schemaManager->listTableColumns([$table]);
 
             foreach ($fields as $orderField => $field) {
                 if (isset($columns[strtolower($orderField)], $columns[strtolower($field)])) {


### PR DESCRIPTION
Fixes the following error:

```
Exception in file vendor/doctrine/dbal/src/Schema/AbstractSchemaManager.php on line 164

Doctrine\DBAL\Schema\AbstractSchemaManager::tablesExist(): Argument #1 ($names) must be of type array, string given, called in vendor/madeyourday/contao-rocksolid-mega-menu/src/Migration/OrderFieldMigration.php on line 43
#0 vendor/madeyourday/contao-rocksolid-mega-menu/src/Migration/OrderFieldMigration.php(43): Doctrine\DBAL\Schema\AbstractSchemaManager->tablesExist('tl_rocksolid_me...')
#1 vendor/contao/core-bundle/src/Migration/MigrationCollection.php(41): MadeYourDay\RockSolidMegaMenu\Migration\OrderFieldMigration->shouldRun()
```

_Note:_ I chose `^3.3` as the minimum Doctrine version since that is the minimum version for Contao 4.13 anyway (which this extension has as the minimum Contao version).